### PR TITLE
Fix bug for peft compatibility

### DIFF
--- a/ptp_utils.py
+++ b/ptp_utils.py
@@ -101,14 +101,15 @@ class AttentionControl(abc.ABC):
 
     def __call__(self, attn, is_cross: bool, place_in_unet: str):
         if self.cur_att_layer >= self.num_uncond_att_layers:
+            attn_ = attn.clone()
             h = attn.shape[0]
-            attn[h // 2 :] = self.forward(attn[h // 2 :], is_cross, place_in_unet)
+            attn_[h // 2 :] = self.forward(attn[h // 2 :], is_cross, place_in_unet)
         self.cur_att_layer += 1
         if self.cur_att_layer == self.num_att_layers + self.num_uncond_att_layers:
             self.cur_att_layer = 0
             self.cur_step += 1
             self.between_steps()
-        return attn
+        return attn_
 
     def reset(self):
         self.cur_step = 0


### PR DESCRIPTION
With this quick fix, break-a-scene could be successfully trained with [peft](https://github.com/huggingface/peft) approaches, such as LoRA and BOFT, without following errors:

```bash
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [10, 4096, 77]], which is output 0 of SoftmaxBackward0, is at version 1; expected version 0 instead. Hint: the backtrace further above shows the operation that failed to compute its gradient. The variable in question was changed in there or anywhere later. Good luck!
```